### PR TITLE
Fix Python 3 compatibility

### DIFF
--- a/sync-pingdom-ec2-security-groups.py
+++ b/sync-pingdom-ec2-security-groups.py
@@ -92,7 +92,7 @@ class SecurityGroupUpdater(object):
     def get_ips(self):
         r = requests.request('GET', self.whitelist, timeout=10)
         r.raise_for_status()
-        return set(r.iter_lines())
+        return set(r.iter_lines(decode_unicode=True))
 
     def create_permission(self, ip):
         return Permission(self.protocol, '{0}/32'.format(ip), self.from_port, self.to_port)


### PR DESCRIPTION
When running with Python 3, `Response.iter_lines` defaults to returning raw
bytes. (Python 2 does return strings.) We now explicitly tell the `requests`
library to decode the response using the appropriate charset.

Fixes #1.