### PR TITLE
added option for allow using different aws profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ script with `--help`:
 
 ```
 $ ./sync-pingdom-ec2-security-groups.py --help
-usage: sync-pingdom-ec2-security-groups.py [-h] [--region REGION]
+usage: sync-pingdom-ec2-security-groups.py [-h] [--profile PROFILE]
+                                           [--region REGION]
                                            [--whitelist WHITELIST]
                                            [--protocol {icmp,tcp,udp}]
                                            [--from-port FROM_PORT]
@@ -35,6 +36,8 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
+  --profile PROFILE     The AWS config profile to use; defaults to the default
+                        profile
   --region REGION       The AWS region where the security groups are located;
                         defaults to the environment's default region
   --whitelist WHITELIST

--- a/sync-pingdom-ec2-security-groups.py
+++ b/sync-pingdom-ec2-security-groups.py
@@ -71,13 +71,12 @@ class PingdomSecurityGroup(object):
             self.sg.authorize_ingress(**p.as_dict())
 
 class SecurityGroupUpdater(object):
-    def __init__(self, region, whitelist, protocol, from_port, to_port, profile, security_groups):
-        self.region = region
+    def __init__(self, session, whitelist, protocol, from_port, to_port, security_groups):
+        self.session = session
         self.whitelist = whitelist
         self.protocol = protocol
         self.from_port = from_port
         self.to_port = to_port
-        self.profile = profile
         self.security_groups = security_groups
 
     def run(self):
@@ -100,14 +99,17 @@ class SecurityGroupUpdater(object):
         return Permission(self.protocol, '{0}/32'.format(ip), self.from_port, self.to_port)
 
     def configure_permissions(self, permissions):
-        boto3.setup_default_session(profile_name=self.profile)
-        ec2 = boto3.resource('ec2', region_name=self.region)
+        ec2 = self.session.resource('ec2')
         for sg_id in self.security_groups:
             sg = PingdomSecurityGroup(ec2.SecurityGroup(sg_id))
             sg.update_permissions(permissions)
 
 def main():
     parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--profile',
+        default=None,
+        help='The AWS config profile to use; defaults to the default profile')
     parser.add_argument(
         '--region',
         default=None,
@@ -132,16 +134,14 @@ def main():
         default=80,
         help='The highest port on which Pingdom probes')
     parser.add_argument(
-        '--profile',
-        default='default',
-        help='AWS credintials profile from ~/.aws/credentials, default: default')
-    parser.add_argument(
         'security-group',
         nargs='+',
         help='One of the security groups to be updated')
     args = parser.parse_args()
 
-    updater = SecurityGroupUpdater(args.region, args.whitelist, args.protocol, args.from_port, args.to_port, args.profile,  getattr(args, 'security-group'))
+    session = boto3.Session(region_name=args.region, profile_name=args.profile)
+
+    updater = SecurityGroupUpdater(session, args.whitelist, args.protocol, args.from_port, args.to_port, getattr(args, 'security-group'))
     updater.run()
 
 if __name__ == '__main__':


### PR DESCRIPTION
~/.aws/config, and ~/.aws/credentials support multiple profiles for different IAM accounts, this add a --profile option to select which one to use, and defaults to "default"